### PR TITLE
LPS-172102 NoSuchRoleException when attempting to add a Role Type assignment when choosing a role with a title that differs from its key

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin User API
 Bundle-SymbolicName: com.liferay.headless.admin.user.api
-Bundle-Version: 22.3.2
+Bundle-Version: 22.4.0
 Export-Package:\
 	com.liferay.headless.admin.user.dto.v1_0,\
 	com.liferay.headless.admin.user.resource.v1_0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Role.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Role.java
@@ -278,7 +278,7 @@ public class Role implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, String> description_i18n;
 
-	@Schema(description = "The role's ID.")
+	@Schema(description = "The role's internal ID.")
 	public Long getId() {
 		return id;
 	}
@@ -300,9 +300,35 @@ public class Role implements Serializable {
 		}
 	}
 
-	@GraphQLField(description = "The role's ID.")
+	@GraphQLField(description = "The role's internal ID.")
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
+
+	@Schema(description = "The role's unique portable ID.")
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	@JsonIgnore
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		try {
+			key = keyUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The role's unique portable ID.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String key;
 
 	@Schema(description = "The role's name.")
 	public String getName() {
@@ -522,6 +548,20 @@ public class Role implements Serializable {
 			sb.append("\"id\": ");
 
 			sb.append(id);
+		}
+
+		if (key != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"key\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(key));
+
+			sb.append("\"");
 		}
 
 		if (name != null) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 8.3.0
+version 8.4.0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/Role.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/Role.java
@@ -204,6 +204,25 @@ public class Role implements Cloneable, Serializable {
 
 	protected Long id;
 
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		try {
+			key = keyUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String key;
+
 	public String getName() {
 		return name;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/RoleSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/RoleSerDes.java
@@ -165,6 +165,20 @@ public class RoleSerDes {
 			sb.append(role.getId());
 		}
 
+		if (role.getKey() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"key\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(role.getKey()));
+
+			sb.append("\"");
+		}
+
 		if (role.getName() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -287,6 +301,13 @@ public class RoleSerDes {
 			map.put("id", String.valueOf(role.getId()));
 		}
 
+		if (role.getKey() == null) {
+			map.put("key", null);
+		}
+		else {
+			map.put("key", String.valueOf(role.getKey()));
+		}
+
 		if (role.getName() == null) {
 			map.put("name", null);
 		}
@@ -372,6 +393,11 @@ public class RoleSerDes {
 			else if (Objects.equals(jsonParserFieldName, "id")) {
 				if (jsonParserFieldValue != null) {
 					role.setId(Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "key")) {
+				if (jsonParserFieldValue != null) {
+					role.setKey((String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -575,10 +575,15 @@ components:
                     type: object
                 id:
                     description:
-                        The role's ID.
+                        The role's internal ID.
                     format: int64
                     readOnly: true
                     type: integer
+                key:
+                    description:
+                        The role's unique portable ID.
+                    readOnly: true
+                    type: string
                 name:
                     description:
                         The role's name.

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1097,7 +1097,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.user.client', and version '4.0.35'."
+        'com.liferay.headless.admin.user.client', and version '4.0.36'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -773,7 +773,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {role(roleId: ___){actions, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, id, name, name_i18n, roleType}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {role(roleId: ___){actions, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, id, key, name, name_i18n, roleType}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the role.")
 	public Role role(@GraphQLName("roleId") Long roleId) throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.35'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.36'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/RoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/RoleResourceImpl.java
@@ -235,6 +235,7 @@ public class RoleResourceImpl extends BaseRoleResourceImpl {
 					contextAcceptLanguage.isAcceptAllLanguages(),
 					role.getDescriptionMap());
 				id = role.getRoleId();
+				key = role.getName();
 				name = role.getTitle(
 					contextAcceptLanguage.getPreferredLocale());
 				name_i18n = LocalizedMapUtil.getI18nMap(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -183,6 +183,7 @@ public abstract class BaseRoleResourceTestCase {
 		Role role = randomRole();
 
 		role.setDescription(regex);
+		role.setKey(regex);
 		role.setName(regex);
 		role.setRoleType(regex);
 
@@ -193,6 +194,7 @@ public abstract class BaseRoleResourceTestCase {
 		role = RoleSerDes.toDTO(json);
 
 		Assert.assertEquals(regex, role.getDescription());
+		Assert.assertEquals(regex, role.getKey());
 		Assert.assertEquals(regex, role.getName());
 		Assert.assertEquals(regex, role.getRoleType());
 	}
@@ -653,6 +655,14 @@ public abstract class BaseRoleResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("key", additionalAssertFieldName)) {
+				if (role.getKey() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("name", additionalAssertFieldName)) {
 				if (role.getName() == null) {
 					valid = false;
@@ -841,6 +851,14 @@ public abstract class BaseRoleResourceTestCase {
 
 			if (Objects.equals("id", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(role1.getId(), role2.getId())) {
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("key", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(role1.getKey(), role2.getKey())) {
 					return false;
 				}
 
@@ -1067,6 +1085,14 @@ public abstract class BaseRoleResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("key")) {
+			sb.append("'");
+			sb.append(String.valueOf(role.getKey()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("name")) {
 			sb.append("'");
 			sb.append(String.valueOf(role.getName()));
@@ -1137,6 +1163,7 @@ public abstract class BaseRoleResourceTestCase {
 				description = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				id = RandomTestUtil.randomLong();
+				key = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				roleType = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/select-reassignment/Role.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/select-reassignment/Role.js
@@ -37,7 +37,7 @@ const Role = ({actionData, actionSectionsIndex, setActionSections}) => {
 					setActionSections((currentSections) => {
 						const updatedSections = [...currentSections];
 						updatedSections[actionSectionsIndex].name =
-							response.name;
+							response.key;
 						updatedSections[actionSectionsIndex].roleType =
 							response.roleType;
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/util/populateAssignmentsData.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/util/populateAssignmentsData.js
@@ -119,7 +119,7 @@ const populateAssignmentsData = (
 					.then((response) => {
 						initialElements[index].data.assignments.sectionsData = {
 							id: response.id,
-							name: response.name,
+							name: response.key,
 							roleType: response.roleType,
 						};
 						setElements([...initialElements]);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/util/populateNotificationsData.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/util/populateNotificationsData.js
@@ -28,7 +28,7 @@ const populateNotificationsData = (initialElements, setElements) => {
 								index
 							].sectionsData = {
 								id: response.id,
-								name: response.name,
+								name: response.key,
 								roleType: response.roleType,
 							};
 


### PR DESCRIPTION
This is an update for [LPS-172102](https://issues.liferay.com/browse/LPS-172102).

@naraandrade the first few commits add the `key` field to the response object.

In the last commit, I attempted to change the spots that I thought were relevant in the workflow designer module, but ultimately I could not test it due to JS errors. If that commit incorrect or incomplete, feel free to discard it.

Thanks!

/cc @zsigmondrab @pei-jung @holatuwol